### PR TITLE
Fix: add a condition to check body params

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -32,7 +32,7 @@ const request = (
       reject(error);
     })
 
-    if(options.method !== 'GET') {
+    if(options.method !== 'GET' && options.body !== undefined) {
       req.write(options.body)
     }
     req.end()


### PR DESCRIPTION
The disable transfer OTP on the transfer control endpoint contains a method of a POST but doesn't have body params so when we call the function request doesn't accept undefined from the body hence it throws this error
![Screenshot from 2022-11-19 11-19-47](https://user-images.githubusercontent.com/76972237/202842207-820c3b03-da53-4ef4-9745-7a043487c117.png)
so I added that check for empty body on post to handle the error.
